### PR TITLE
Fix composer.json Laravel requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "vemcogroup/laravel-sparkpost-driver",
-    "description": "SparkPost driver to use with Laravel 6.x|7.x",
+    "description": "SparkPost driver to use with Laravel 7.x",
     "keywords": [
         "mail",
         "laravel",
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.2",
         "guzzlehttp/guzzle": "^6.3",
-        "laravel/framework": "^6.0|^7.0",
+        "laravel/framework": "^7.0",
         "swiftmailer/swiftmailer": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Version 3 of this package doesn't work with Laravel 6. This change prevents it from being installed in Laravel 6 projects.

Also reported in issue https://github.com/vemcogroup/laravel-sparkpost-driver/issues/6.