### PR TITLE
Update Guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "laravel/framework": "^7.0|^8.0",
         "swiftmailer/swiftmailer": "^6.0"
     },


### PR DESCRIPTION
Laravel 8 updated the Guzzle version https://github.com/laravel/laravel/blob/master/composer.json#L14 it will need to be updated here as well before being able to install with Laravel.