### PR TITLE
Docs/jb-clarify-readme-mail-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ SPARKPOST_SECRET=__Your_key_here__
 Finally you need to set your mail driver to SparkPost. You can do this by changing the driver in `config/mail.php`
 
 ```php
-'driver' => env('MAIL_DRIVER', 'sparkpost'),
+'driver' => env('MAIL_MAILER', 'sparkpost'),
 ```
 
 Or by setting the environment variable `MAIL_DRIVER` in your `.env` file
@@ -95,9 +95,7 @@ Or by setting the environment variable `MAIL_DRIVER` in your `.env` file
 MAIL_DRIVER=sparkpost
 ```
 
-**Laravel 7**
-
-If you are using a clean Laravel 7.x installation its important you add the following sparkpost config in `config/mail.php` mailer section.
+For any versions after Laravel 7.x, you will also need to add back in the sparkpost driver to the `config/mail.php` mailer section.
 
 ```php
 'mailers' => [
@@ -108,7 +106,11 @@ If you are using a clean Laravel 7.x installation its important you add the foll
     ...
 ],
 ```
-And replace the `MAIL_DRIVER` from .env with `MAIL_MAILER`, make sure to keep the sparkpost config on `config/services.php`.
+
+**Laravel 5**
+
+If you are still using Laravel 5, the `MAIL_MAILER` referenced above will instead be `MAIL_DRIVER`.
+
 
 ## Helper functions
 

--- a/README.md
+++ b/README.md
@@ -85,17 +85,21 @@ SPARKPOST_SECRET=__Your_key_here__
 
 Finally you need to set your mail driver to SparkPost. You can do this by changing the driver in `config/mail.php`
 
+> If you are still using Laravel 5, the `MAIL_MAILER` referenced below will instead be `MAIL_DRIVER`.
+
 ```php
 'driver' => env('MAIL_MAILER', 'sparkpost'),
 ```
 
-Or by setting the environment variable `MAIL_DRIVER` in your `.env` file
+Or by setting the environment variable `MAIL_MAILER` in your `.env` file
 
 ```php
-MAIL_DRIVER=sparkpost
+MAIL_MAILER=sparkpost
 ```
 
-For any versions after Laravel 7.x, you will also need to add back in the sparkpost driver to the `config/mail.php` mailer section.
+You will also need to add the `sparkpost` driver to the `config/mail.php` mailer section.
+
+> Laravel 5 already includes this configuration
 
 ```php
 'mailers' => [
@@ -106,11 +110,6 @@ For any versions after Laravel 7.x, you will also need to add back in the sparkp
     ...
 ],
 ```
-
-**Laravel 5**
-
-If you are still using Laravel 5, the `MAIL_MAILER` referenced above will instead be `MAIL_DRIVER`.
-
 
 ## Helper functions
 


### PR DESCRIPTION
When setting this up for Laravel 9, it was unclear that the `mail.php` needed the `sparpost` driver to be set as well. The current readme only specifies this is needed for Laravel 7. I updated this to assume most people coming to install this package are using a version of Laravel that does not include sparkpost by default.