### PR TITLE
Use Json body to define mail options

### DIFF
--- a/src/Transport/SparkPostTransport.php
+++ b/src/Transport/SparkPostTransport.php
@@ -83,6 +83,7 @@ class SparkPostTransport implements TransportInterface
         $response = $this->client->request('POST', $this->getEndpoint() . '/transmissions', [
             'headers' => $headers,
             'json' => array_merge([
+                'options' => $this->getOptions(),
                 'recipients' => $recipients,
                 'content' => [
                     'from' => $this->getFrom($message),
@@ -92,7 +93,7 @@ class SparkPostTransport implements TransportInterface
                     'text' => $message->getTextBody(),
                     'attachments' => $this->getAttachments($message),
                 ],
-            ], $this->options),
+            ]),
         ]);
 
         $message->getHeaders()->addTextHeader(


### PR DESCRIPTION
This PR will update to use the JSON body to provide the mailable options. 

https://developers.sparkpost.com/api/transmissions/#header-request-body:~:text=%7B%0A%20%20%22options%22%3A%20%7B%0A%20%20%20%20%22click_tracking%22%3A%20false%2C%0A%20%20%20%20%22transactional%22%3A%20true%2C%0A%20%20%20%20%22ip_pool%22%3A%20%22my_ip_pool%22%2C%0A%20%20%20%20%22inline_css%22%3A%20true%0A%20%20%7D%2C

I'm unsure if Sparkpost has updated its API recently, as I haven't used it regularly. However, using the current method of setting options it doesn't work when updating the config settings. 

If I'm incorrect or there are any issues with the PR please let me know. 