### PR TITLE
Correctly add config options to the Guzzle client

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.github export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.cache
 /vendor/
 .idea
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "symfony/mailer": "^6.0|^7.0",
         "ext-json": "*"
     },
+    "require-dev": {
+        "orchestra/testbench": "^10.0",
+        "pestphp/pest-plugin-laravel": "^3.0"
+    },
     "autoload": {
         "psr-4": {
             "Vemcogroup\\SparkPostDriver\\": "src/"
@@ -29,8 +33,16 @@
             "src/helpers.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Vemcogroup\\SparkPostDriver\\Tests\\": "tests/"
+        }
+    },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {
@@ -38,6 +50,9 @@
                 "Vemcogroup\\SparkPostDriver\\SparkPostDriverServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/pest"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/SparkPostDriverServiceProvider.php
+++ b/src/SparkPostDriverServiceProvider.php
@@ -16,7 +16,7 @@ class SparkPostDriverServiceProvider extends ServiceProvider
                 $config = config('services.sparkpost', []);
                 $sparkpostOptions = $config['options'] ?? [];
                 $guzzleOptions = $config['guzzle'] ?? [];
-                $client = $this->app->make(Client::class, $guzzleOptions);
+                $client = $this->app->make(Client::class, ['config' => $guzzleOptions]);
 
                 return new SparkPostTransport($client, $config['secret'], $sparkpostOptions);
             });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Vemcogroup\SparkPostDriver\Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/SparkpostTransportServiceProviderTest.php
+++ b/tests/SparkpostTransportServiceProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Mail\Mailer;
+use Vemcogroup\SparkPostDriver\Transport\SparkPostTransport;
+
+it('registers the Sparkpost transport with the Laravel MailManager', function () {
+    $manager = app('mail.manager');
+    config()->set('services.sparkpost', [
+        'secret' => 'SPARKPOST_SECRET',
+    ]);
+
+    $mailer = $manager->driver('sparkpost');
+
+    expect($mailer)->toBeInstanceOf(Mailer::class);
+    $transport = $mailer->getSymfonyTransport();
+    expect($transport)->toBeInstanceOf(SparkPostTransport::class)
+        ->getEndpoint()->toBe('https://api.sparkpost.com/api/v1');
+});
+
+it('passes any configured options to the transport', function () {
+    $manager = app('mail.manager');
+    config()->set('services.sparkpost', [
+        'secret'  => 'SPARKPOST_SECRET',
+        'options' => ['open_tracking' => true],
+    ]);
+
+    $mailer = $manager->driver('sparkpost');
+
+    expect($mailer->getSymfonyTransport()->getOptions())->toBe([
+        'open_tracking' => true,
+    ]);
+});
+
+it('allows customizing the Sparkpost endpoint', function () {
+    $manager = app('mail.manager');
+    config()->set('services.sparkpost', [
+        'secret'  => 'SPARKPOST_SECRET',
+        'options' => [
+            'endpoint' => $endpoint = 'https://api.eu.sparkpost.com/api/v1',
+        ],
+    ]);
+
+    $mailer = $manager->driver('sparkpost');
+
+    expect($mailer->getSymfonyTransport()->getEndpoint())->toBe($endpoint);
+});
+
+it('passes any configured guzzle options to the Guzzle client', function () {
+    config()->set('services.sparkpost', [
+        'secret' => 'SPARKPOST_SECRET',
+        'guzzle' => [
+            'timeout'         => 100,
+            'connect_timeout' => 20,
+        ],
+    ]);
+
+    $manager   = app('mail.manager');
+    $transport = $manager->driver('sparkpost')->getSymfonyTransport();
+
+    $guzzleClient = (new \ReflectionClass($transport))->getProperty('client')->getValue($transport);
+
+    expect($guzzleClient->getConfig())->toMatchArray([
+        'timeout'         => 100,
+        'connect_timeout' => 20,
+    ]);
+});

--- a/tests/SparkpostTransportTest.php
+++ b/tests/SparkpostTransportTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Testing\FileFactory;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\SentMessage;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\HtmlString;
+use Vemcogroup\SparkPostDriver\Transport\SparkpostTransport;
+
+it('sends an email via the Sparkpost Transmissions API', function () {
+    [
+        'client'       => $client,
+        'sentRequests' => $sentRequests,
+    ] = createGuzzleClient([
+        new Response(200, ['Content-Type' => 'application/json'], json_encode([
+            'results' => ['id' => 'MESSAGE_ID'],
+        ], JSON_THROW_ON_ERROR)),
+    ]);
+
+    Mail::extend('sparkpost', fn () => new SparkPostTransport($client, 'secret_key'));
+
+    $attachmentA = (new FileFactory)->image('attachment-a.png', 100, 100);
+    $attachmentB = (new FileFactory)->image('attachment-b.png', 50, 50);
+
+    $message = Mail::mailer('sparkpost')
+        ->to([
+            ['name' => 'Recipient A', 'email' => 'recipient-a@example.com'],
+            ['name' => 'Recipient B', 'email' => 'recipient-b@example.com'],
+        ])
+        ->cc([
+            ['name' => 'CC A', 'email' => 'cc-a@example.com'],
+            ['name' => 'CC B', 'email' => 'cc-b@example.com'],
+        ])
+        ->bcc([
+            ['name' => 'BCC A', 'email' => 'bcc-a@example.com'],
+            ['name' => 'BCC B', 'email' => 'bcc-b@example.com'],
+        ])
+        ->send(new class([$attachmentA, $attachmentB]) extends Mailable {
+            public function __construct(private array $attachmentsToSend) {}
+
+            public function build(): Mailable
+            {
+                foreach ($this->attachmentsToSend as $attachment) {
+                    $this->attach($attachment, ['as' => $attachment->name, 'mime' => 'image/png']);
+                }
+
+                return $this->html('HTML content')
+                    ->text(new HtmlString('Text content'))
+                    ->subject('Mail subject')
+                    ->from('sender@example.com', 'Sender name')
+                    ->replyTo('reply-to@example.com', 'Reply To');
+            }
+        });
+
+    expect($message)->toBeInstanceOf(SentMessage::class)
+        ->and($message->getOriginalMessage()->getHeaders()->getHeaderBody('X-Sparkpost-Transmission-ID'))->toBe('MESSAGE_ID');
+    expect($sentRequests)->toHaveCount(1);
+    /** @var \GuzzleHttp\Psr7\Request $request */
+    $request = $sentRequests[0]['request'];
+    expect($request)
+        ->getUri()->toEqual('https://api.sparkpost.com/api/v1/transmissions')
+        ->getHeaderLine('authorization')->toBe('secret_key')
+        ->getHeaderLine('content-type')->toBe('application/json')
+        ->and(json_decode($request->getBody()->getContents(), true))->toEqual([
+            'recipients' => [
+                ['address' => ['email' => 'recipient-a@example.com', 'name' => 'Recipient A', 'header_to' => 'recipient-a@example.com,recipient-b@example.com']],
+                ['address' => ['email' => 'recipient-b@example.com', 'name' => 'Recipient B', 'header_to' => 'recipient-a@example.com,recipient-b@example.com']],
+
+                ['address' => ['email' => 'cc-a@example.com', 'name' => 'CC A', 'header_to' => 'recipient-a@example.com,recipient-b@example.com']],
+                ['address' => ['email' => 'cc-b@example.com', 'name' => 'CC B', 'header_to' => 'recipient-a@example.com,recipient-b@example.com']],
+
+                ['address' => ['email' => 'bcc-a@example.com', 'name' => 'BCC A', 'header_to' => 'recipient-a@example.com,recipient-b@example.com']],
+                ['address' => ['email' => 'bcc-b@example.com', 'name' => 'BCC B', 'header_to' => 'recipient-a@example.com,recipient-b@example.com']],
+            ],
+            'content'    => [
+                'subject'     => 'Mail subject',
+                'from'        => ['name' => 'Sender name', 'email' => 'sender@example.com'],
+                'reply_to'    => 'Reply To <reply-to@example.com>',
+                'html'        => 'HTML content',
+                'text'        => 'Text content',
+                'attachments' => [
+                    [
+                        'name' => $attachmentA->name,
+                        'type' => $attachmentA->getMimeType(),
+                        'data' => base64_encode($attachmentA->getContent()),
+                    ],
+                    [
+                        'name' => $attachmentB->name,
+                        'type' => $attachmentB->getMimeType(),
+                        'data' => base64_encode($attachmentB->getContent()),
+                    ],
+                ],
+                'headers'     => [
+                    'CC' => 'cc-a@example.com,cc-b@example.com',
+                ],
+            ],
+        ]);
+    expect($message->toString())
+        ->not->toContain('bcc-a@example.com')
+        ->not->toContain('bcc-b@example.com');
+});
+
+it('allows customizing the request body', function () {
+    ['client' => $client, 'sentRequests' => $sentRequests] = createGuzzleClient([
+        new Response(200, ['Content-Type' => 'application/json'], '{"results":{"id":"MESSAGE_ID"}}'),
+    ]);
+    Mail::extend('sparkpost', fn () => new SparkPostTransport($client, 'secret_key', [
+        'options'     => [
+            'click_tracking' => false,
+        ],
+        'description' => 'Test',
+    ]));
+
+    sendSimpleEmail();
+
+    expect($sentRequests)->toHaveCount(1);
+    /** @var \GuzzleHttp\Psr7\Request $request */
+    $request = $sentRequests[0]['request'];
+    $body    = json_decode($request->getBody()->getContents(), true);
+    expect($body['options'])->toEqual(['click_tracking' => false]);
+    expect($body['description'])->toEqual('Test');
+});
+
+/**
+ * @param list<Response> $responses
+ *
+ * @return array{client: Client, sentRequests: \Illuminate\Support\Collection<int, Response>}
+ */
+function createGuzzleClient(array $responses): array
+{
+    $handler = HandlerStack::create(new MockHandler($responses));
+
+    $sentRequests = collect();
+    $history      = Middleware::history($sentRequests);
+
+    $handler->push($history);
+
+    return [
+        'client'       => new Client(['handler' => $handler]),
+        'sentRequests' => $sentRequests,
+    ];
+}
+
+function sendSimpleEmail(): SentMessage
+{
+    return Mail::mailer('sparkpost')
+        ->to([['name' => 'Recipient', 'email' => 'recipient@example.com']])
+        ->send(new class extends Mailable {
+            public function build(): Mailable
+            {
+                return $this->html('HTML content')->text(new HtmlString('Text content'));
+            }
+        });
+}
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vemcogroup\SparkPostDriver\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Vemcogroup\SparkPostDriver\SparkPostDriverServiceProvider;
+
+class TestCase extends Orchestra
+{
+    /**
+     * Get package providers.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            SparkPostDriverServiceProvider::class,
+        ];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    public function defineEnvironment($app): void
+    {
+        config()->set('mail.mailers.sparkpost', [
+            'transport' => 'sparkpost',
+        ]);
+    }
+}


### PR DESCRIPTION
The `guzzle` options that could be set via the config file were never passed to the Guzzle client object. I also added tests.