### PR TITLE
Add support for inline images

### DIFF
--- a/tests/views/mail-with-embed.blade.php
+++ b/tests/views/mail-with-embed.blade.php
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <img src="{{ $message->embedData(base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='), 'img.png') }}">
+  </body>
+</html>


### PR DESCRIPTION
This PR adds the support for using inline images. At the moment embedded images are only sent as attachment, and therefore not shown inline in the mail content itself.

SparkPost docs: https://developers.sparkpost.com/api/transmissions/#header-inline-image-object