### PR TITLE
Use correct cid depending on Laravel version for inline images

### DIFF
--- a/tests/views/mail-with-embed.blade.php
+++ b/tests/views/mail-with-embed.blade.php
@@ -1,5 +1,5 @@
 <html>
   <body>
-    <img src="{{ $message->embedData(base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='), 'img.png') }}">
+    <img src="{{ $message->embedData(base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='), 'img.png', 'image/png') }}">
   </body>
 </html>


### PR DESCRIPTION
This PR fixes a issue with embedded images. Since Laravel 12 the content id is used as cid value instead of the file name (see [v11](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Mail/Message.php#L389) and [v12](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Mail/Message.php#L385)). This cid must match the attachment name sent to Sparkpost to show the images inline.